### PR TITLE
feat: add car sprites and track styling

### DIFF
--- a/ra-frontend/app/game/[roomId]/page.tsx
+++ b/ra-frontend/app/game/[roomId]/page.tsx
@@ -43,13 +43,13 @@ export default function RacePage({ params }: Props) {
 	/* --- live game state via WS hook --------------------------- */
 	const { cars, standings, maxLaps, ready, send } = useRaceSocket(roomId123, countdownFunc);
 	const me = userId ? cars[userId] : undefined;
-	useEffect(() => {
-		if (!ready) return;
+        useEffect(() => {
+                if (!ready || !roomId || !userId) return;
 
-		// send join message to server
-		console.log('Joining room:', roomId, 'as user:', userId);
-		send({ type: 'join', playerId: userId });
-	}, [ready]);
+                // send join message to server
+                console.log('Joining room:', roomId, 'as user:', userId);
+                send({ type: 'join', playerId: userId });
+        }, [ready, roomId, send, userId]);
 
 	useEffect(() => {
 		if (!showResults && standings.length > 0 && standings.every((s) => s.finished)) {

--- a/ra-frontend/components/TrackCanvas.tsx
+++ b/ra-frontend/components/TrackCanvas.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTrackPoints } from '@/hooks/useTrackPoints';
 import type { InputType } from '@/hooks/useRaceSocket';
 import type { PlayerSnapshot } from '@/hooks/useRaceSocket';
@@ -31,47 +31,73 @@ const MODE_STYLE: Record<InputType, { stroke: string; width: number }> = {
 };
 
 export default function TrackCanvas({ track, cars, positions }: Props) {
-	const ref = useRef<HTMLCanvasElement>(null);
-	const { pts: trackPts } = useTrackPoints(track);
+        const ref = useRef<HTMLCanvasElement>(null);
+        const carImg = useRef<HTMLImageElement | null>(null);
+        const [carReady, setCarReady] = useState(false);
+        const { pts: trackPts } = useTrackPoints(track);
 
 	/* ---------------- helpers ---------------- */
-	const bounds = (() => {
-		const xs = trackPts.map((p) => p[0]);
-		const ys = trackPts.map((p) => p[1]);
-		return {
-			minX: Math.min(...xs),
-			maxX: Math.max(...xs),
-			minY: Math.min(...ys),
-			maxY: Math.max(...ys),
-		};
-	})();
-	const scale = (x: number, y: number, w: number, h: number) => {
-		const nx = ((x - bounds.minX) / (bounds.maxX - bounds.minX)) * w;
-		const ny = h - ((y - bounds.minY) / (bounds.maxY - bounds.minY)) * h;
-		return [nx, ny];
-	};
+        const bounds = useMemo(() => {
+                const xs = trackPts.map((p) => p[0]);
+                const ys = trackPts.map((p) => p[1]);
+                return {
+                        minX: Math.min(...xs),
+                        maxX: Math.max(...xs),
+                        minY: Math.min(...ys),
+                        maxY: Math.max(...ys),
+                };
+        }, [trackPts]);
+        const scale = useCallback((x: number, y: number, w: number, h: number) => {
+                const nx = ((x - bounds.minX) / (bounds.maxX - bounds.minX)) * w;
+                const ny = h - ((y - bounds.minY) / (bounds.maxY - bounds.minY)) * h;
+                return [nx, ny];
+        }, [bounds]);
 
-	/* ---------------- paint STATIC track ---------------- */
-	useEffect(() => {
-		if (!trackPts.length) return;
-		const c = ref.current;
-		if (!c) return;
-		const ctx = c.getContext('2d')!;
-		const { width: w, height: h } = c;
+        /* ---------------- load assets ---------------- */
+        useEffect(() => {
+                const img = new Image();
+                img.src = '/f1-car.svg';
+                img.onload = () => {
+                        carImg.current = img;
+                        setCarReady(true);
+                };
+        }, []);
 
-		ctx.clearRect(0, 0, w, h);
-		ctx.lineWidth = 4;
-		ctx.lineCap = 'round';
-		ctx.strokeStyle = '#e5e7eb';
+        const drawTrack = useCallback((ctx: CanvasRenderingContext2D, w: number, h: number) => {
+                ctx.clearRect(0, 0, w, h);
+                ctx.fillStyle = '#14532d'; // grass
+                ctx.fillRect(0, 0, w, h);
 
-		ctx.beginPath();
-		trackPts.forEach(([x, y], i) => {
-			const [px, py] = scale(x, y, w, h);
-			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-			i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py);
-		});
-		ctx.stroke();
-	}, [trackPts]);
+                const path = new Path2D();
+                trackPts.forEach(([x, y], i) => {
+                        const [px, py] = scale(x, y, w, h);
+                        if (i === 0) path.moveTo(px, py);
+                        else path.lineTo(px, py);
+                });
+
+                ctx.lineCap = 'round';
+                ctx.lineJoin = 'round';
+
+                // white edges then grey road
+                ctx.strokeStyle = '#f4f4f5';
+                ctx.lineWidth = 34;
+                ctx.stroke(path);
+
+                ctx.strokeStyle = '#6b7280';
+                ctx.lineWidth = 26;
+                ctx.stroke(path);
+        }, [trackPts, scale]);
+
+        /* ---------------- paint STATIC track ---------------- */
+        useEffect(() => {
+                if (!trackPts.length) return;
+                const c = ref.current;
+                if (!c) return;
+                const ctx = c.getContext('2d')!;
+                const { width: w, height: h } = c;
+
+                drawTrack(ctx, w, h);
+        }, [trackPts, drawTrack]);
 
 	/* ---------------- paint DYNAMIC cars ---------------- */
 	useEffect(() => {
@@ -81,42 +107,33 @@ export default function TrackCanvas({ track, cars, positions }: Props) {
 		const ctx = c.getContext('2d')!;
 		const { width: w, height: h } = c;
 
-		/* clear ONLY the dynamic layer */
-		ctx.clearRect(0, 0, w, h);
+                drawTrack(ctx, w, h);
 
-		/* quick redraw of grey track */
-		ctx.lineWidth = 4;
-		ctx.strokeStyle = '#e5e7eb';
-		ctx.beginPath();
-		trackPts.forEach(([x, y], i) => {
-			const [px, py] = scale(x, y, w, h);
-			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-			i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py);
-		});
-		ctx.stroke();
+                /* decide the source of dots */
+                const dots: Pos[] = positions ? positions : cars ? Object.values(cars) : [];
 
-		/* decide the source of dots */
-		const dots: Pos[] = positions ? positions : cars ? Object.values(cars) : [];
+                dots.forEach((p) => {
+                        const [cx, cy] = scale(p.x, p.y, w, h);
+                        // colour ring behind sprite
+                        ctx.fillStyle = p.color ?? '#f87171';
+                        ctx.beginPath();
+                        ctx.arc(cx, cy, 12, 0, Math.PI * 2);
+                        ctx.fill();
 
-		dots.forEach((p) => {
-			const [cx, cy] = scale(p.x, p.y, w, h);
+                        if (carReady && carImg.current) {
+                                ctx.drawImage(carImg.current, cx - 12, cy - 12, 24, 24);
+                        }
 
-			// inner solid circle (driver colour)
-			ctx.fillStyle = p.color ?? '#f87171';
-			ctx.beginPath();
-			ctx.arc(cx, cy, 14, 0, Math.PI * 2);
-			ctx.fill();
-
-			// outer ring – mode indicator
-			const mode = p.mode ?? 'BASE';
-			const { stroke, width } = MODE_STYLE[mode];
-			ctx.lineWidth = width;
-			ctx.strokeStyle = stroke;
-			ctx.beginPath();
-			ctx.arc(cx, cy, 16, 0, Math.PI * 2);
-			ctx.stroke();
-		});
-	}, [cars, positions, trackPts]);
+                        // outer ring – mode indicator
+                        const mode = p.mode ?? 'BASE';
+                        const { stroke, width } = MODE_STYLE[mode];
+                        ctx.lineWidth = width;
+                        ctx.strokeStyle = stroke;
+                        ctx.beginPath();
+                        ctx.arc(cx, cy, 14, 0, Math.PI * 2);
+                        ctx.stroke();
+                });
+        }, [cars, positions, trackPts, carReady, drawTrack, scale]);
 
 	return <canvas ref={ref} className="h-full w-full rounded bg-neutral-900/40" width={1500} height={625} />;
 }

--- a/ra-frontend/public/f1-car.svg
+++ b/ra-frontend/public/f1-car.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 32">
+  <rect x="28" y="0" width="8" height="32" fill="white"/>
+  <rect x="0" y="12" width="20" height="8" fill="white"/>
+  <rect x="44" y="12" width="20" height="8" fill="white"/>
+  <rect x="22" y="4" width="20" height="24" fill="white"/>
+  <rect x="27" y="8" width="10" height="16" fill="white"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace circular car markers with F1-styled sprites and mode rings
- render tracks with white edges and grey road for a more game-like look
- fix race join effect dependencies

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6896308505508323bf9ac45cc669cf39