### PR TITLE
2026 F1 rules: new race model, battery system and UI overhaul

### DIFF
--- a/ra-backend/src/physics.ts
+++ b/ra-backend/src/physics.ts
@@ -1,100 +1,107 @@
 // src/physics.ts
 //--------------------------------------------------------------
-//  Simplified racing physics with GAME MODES – v9
-//  (29 May 2025)
+//  2026-inspired racing physics model for RadioActive
 //
-//  • Track is pre‑classified into fixed ACCEL / BRAKE zones at load‑time.
-//  • BASE / PUSH / ERS / CONSERVE modes restored (no curvature look‑ahead).
-//  • Constant, deterministic behaviour lap‑after‑lap.
+//  Highlights:
+//  • New race modes inspired by 2026 F1 concepts (X/Z aero behavior).
+//  • Battery deployment/harvest model with brake-zone regen only.
+//  • Zone-aware speed profiles with deterministic server-side simulation.
 //--------------------------------------------------------------
 
-/* ---------- constants ---------- */
-export const g = 9.81; // gravity (m s⁻²) – reserved for future grip calcs
+export const g = 9.81;
 
-const ACCEL_RATE = 10; // m s⁻² constant propulsion
-const BRAKE_RATE = 30; // m s⁻² constant braking
-const MAX_SPEED = 90; // m s⁻¹  ≈ 324 km h⁻¹
-const MIN_SPEED = 5; // m s⁻¹  stall‑avoid
-const BRAKE_ZONE_VMAX = 45; // m s⁻¹  (≈ 162 km h⁻¹) speed cap in BRAKE zones
+const ACCEL_RATE = 11;
+const BRAKE_RATE = 34;
+const MAX_SPEED = 95;
+const MIN_SPEED = 6;
 
-// Energy‑recovery system (ERS)
-const ERS_CAP = 4000; // J (full charge)
-const ERS_DRAIN = 120; // J s⁻¹ while ERS active
-const ERS_REGEN = 35; // J s⁻¹ while coasting (CONSERVE)
+// Base speed profile
+const STRAIGHT_VMAX = 93;
+const CORNER_VMAX = 52;
 
-// PUSH mode modifiers
-const PUSH_VMAX_STRAIGHT = 1.1; // +10 % in ACCEL zones
-const PUSH_VMAX_BRAKE = 0.9; // −10 % in BRAKE zones
-const PUSH_ACCEL_GAIN = 1.3; // +30 % propulsion
+// 2026-inspired battery model (displayed as 0-100%)
+const BATTERY_CAPACITY = 100;
+const DEPLOY_DRAIN = 18; // %/s
+const ATTACK_DRAIN = 10; // %/s
+const XMODE_DRAIN = 14; // %/s
+const BRAKE_REGEN = 20; // %/s (only in corner/brake zones)
+const HARVEST_REGEN = 32; // %/s in dedicated HARVEST mode and corners
 
-// Track classification thresholds
-const CURV_THRESH = 0.001; // |κ| ≤ 5×10⁻2 m⁻¹ ⇒ straight
-const NARROW_WIDTH = 3.7; // anything narrower ⇒ BRAKE zone
+// Mode tuning
+const ATTACK_ACCEL_GAIN = 1.25;
+const ATTACK_STRAIGHT_VMAX = 1.06;
 
-/* ---------- helpers ---------- */
+const XMODE_STRAIGHT_VMAX = 1.12; // low drag
+const XMODE_CORNER_VMAX = 0.9; // low downforce penalty
+const XMODE_BRAKE_PENALTY = 0.9;
+
+const HARVEST_ACCEL_SCALE = 0.82;
+const HARVEST_VMAX_SCALE = 0.88;
+
+const ZMODE_CORNER_VMAX = 1.1; // high downforce
+const ZMODE_STRAIGHT_VMAX = 0.95;
+const ZMODE_BRAKE_GAIN = 1.1;
+
+const CURV_THRESH = 0.001;
+const NARROW_WIDTH = 3.7;
+
 export class Point {
 	constructor(public x: number, public y: number, public w: number) { }
 }
 
-// Signed curvature for local triplet (used once at load‑time)
 function curvature(a: Point, b: Point, c: Point) {
 	const [x1, y1, x2, y2, x3, y3] = [a.x, a.y, b.x, b.y, c.x, c.y];
 	const aLen = Math.hypot(x2 - x3, y2 - y3);
 	const bLen = Math.hypot(x1 - x3, y1 - y3);
 	const cLen = Math.hypot(x1 - x2, y1 - y2);
 	const area = 0.5 * Math.abs(x1 * (y2 - y3) + x2 * (y3 - y1) + x3 * (y1 - y2));
-	return (4 * area) / (aLen * bLen * cLen); // signed κ – magnitude only later
+	return (4 * area) / (aLen * bLen * cLen);
 }
 
-/* ---------- track & sectors ---------- */
 export enum Zone {
 	ACCEL,
 	BRAKE,
 }
 
 export class Sector {
-	zone: Zone; // predetermined driving behaviour
-	segLen: number; // length of this segment (m)
-	cumLen = 0; // distance from start‑line to segment start (m)
+	zone: Zone;
+	segLen: number;
+	cumLen = 0;
 
 	constructor(public p: Point, public curv: number, public width: number, dl: number) {
 		this.segLen = dl;
-		// Decide zone once – fixed for every lap
 		this.zone = Math.abs(curv) > CURV_THRESH || width < NARROW_WIDTH ? Zone.BRAKE : Zone.ACCEL;
 	}
 }
 
 export class Track {
 	sectors: Sector[] = [];
-	total = 0; // full lap length (m)
+	total = 0;
 
 	constructor(pts: Point[]) {
-		// Build sectors from adjacent triplets
 		for (let i = 1; i < pts.length - 1; i++) {
 			const k = curvature(pts[i - 1], pts[i], pts[i + 1]);
 			const dl = Math.hypot(pts[i].x - pts[i + 1].x, pts[i].y - pts[i + 1].y);
 			this.sectors.push(new Sector(pts[i], k, pts[i].w, dl));
 		}
-		// Prefix‑sum cumulative distance
 		for (const sec of this.sectors) {
 			sec.cumLen = this.total;
 			this.total += sec.segLen;
 		}
 	}
 
-	/** Internal: sector index at distance *m* along centre‑line (wraps). */
 	private sectorIndex(m: number) {
 		const d = ((m % this.total) + this.total) % this.total;
 		let i = this.sectors.length - 1;
 		while (i >= 0 && d < this.sectors[i].cumLen) i--;
 		return i;
 	}
+
 	sectorAt(m: number) {
 		return this.sectors[this.sectorIndex(m)];
 	}
 }
 
-/* ---------- CSV loader ---------- */
 export function buildTrackFromCSV(csv: string) {
 	const pts = csv
 		.trim()
@@ -107,8 +114,7 @@ export function buildTrackFromCSV(csv: string) {
 	return new Track(pts);
 }
 
-/* ---------- player (single‑car) ---------- */
-export type Mode = 'BASE' | 'PUSH' | 'ERS' | 'CONSERVE';
+export type Mode = 'RACE' | 'ATTACK' | 'DEPLOY' | 'HARVEST' | 'XMODE' | 'ZMODE';
 
 export class Player {
 	id = '';
@@ -117,87 +123,100 @@ export class Player {
 	v = 0;
 	x = 0;
 	y = 0;
-	lap = 0; // completed full laps
+	lap = 0;
 	finished = false;
-	finishedAt: number | null = null; // timestamp when finished
-	// Position & kinematics
-	// Game state
+	finishedAt: number | null = null;
 
-	ers = ERS_CAP;
-	mode: Mode = 'BASE';
+	battery = BATTERY_CAPACITY;
+	mode: Mode = 'RACE';
 
 	command(m: Mode) {
 		this.mode = m;
 	}
 
-	/** Advance the car by *dt* seconds on *track*. */
 	step(track: Track, dt: number) {
 		const sec = track.sectorAt(this.d);
+		const inCorner = sec.zone === Zone.BRAKE;
 
-		/* ---- base parameters (zone‑dependent) ---- */
-		let vmax = sec.zone === Zone.ACCEL ? MAX_SPEED : BRAKE_ZONE_VMAX;
+		let vmax = inCorner ? CORNER_VMAX : STRAIGHT_VMAX;
 		let accel = ACCEL_RATE;
 		let brake = BRAKE_RATE;
+		let batteryDrain = 0;
+		let batteryGain = 0;
 
-		/* ---- mode modifiers ---- */
 		switch (this.mode) {
-			case 'PUSH':
-				vmax *= sec.zone === Zone.ACCEL ? PUSH_VMAX_STRAIGHT : PUSH_VMAX_BRAKE;
-				accel *= PUSH_ACCEL_GAIN;
+			case 'ATTACK':
+				accel *= ATTACK_ACCEL_GAIN;
+				if (!inCorner) vmax *= ATTACK_STRAIGHT_VMAX;
+				batteryDrain += ATTACK_DRAIN;
 				break;
-
-			case 'ERS':
-				if (this.ers > 0) {
-					vmax *= 1.15;
-					accel *= 1.9;
-					this.ers = Math.max(0, this.ers - ERS_DRAIN * dt);
+			case 'DEPLOY':
+				accel *= 1.45;
+				vmax *= 1.08;
+				batteryDrain += DEPLOY_DRAIN;
+				break;
+			case 'HARVEST':
+				accel *= HARVEST_ACCEL_SCALE;
+				vmax *= HARVEST_VMAX_SCALE;
+				if (inCorner) batteryGain += HARVEST_REGEN;
+				break;
+			case 'XMODE':
+				if (inCorner) {
+					vmax *= XMODE_CORNER_VMAX;
+					brake *= XMODE_BRAKE_PENALTY;
 				} else {
-					this.mode = 'BASE';
+					vmax *= XMODE_STRAIGHT_VMAX;
+				}
+				batteryDrain += XMODE_DRAIN;
+				break;
+			case 'ZMODE':
+				if (inCorner) {
+					vmax *= ZMODE_CORNER_VMAX;
+					brake *= ZMODE_BRAKE_GAIN;
+				} else {
+					vmax *= ZMODE_STRAIGHT_VMAX;
 				}
 				break;
-
-			case 'CONSERVE':
-				vmax *= 0.9;
-				accel *= 0.6;
-				brake *= 0.8;
-				this.ers = Math.min(ERS_CAP, this.ers + ERS_REGEN * dt);
+			case 'RACE':
+			default:
 				break;
 		}
 
-		// Clamp speed limits
+		// Automatic regen only in corner/brake zones (no MGU-H style always-on harvest)
+		if (inCorner) {
+			batteryGain += BRAKE_REGEN;
+		}
+
+		if (batteryDrain > 0) {
+			if (this.battery <= 0) {
+				this.mode = 'RACE';
+				batteryDrain = 0;
+			} else {
+				this.battery = Math.max(0, this.battery - batteryDrain * dt);
+			}
+		}
+
+		if (batteryGain > 0) {
+			this.battery = Math.min(BATTERY_CAPACITY, this.battery + batteryGain * dt);
+		}
+
 		vmax = Math.min(MAX_SPEED, Math.max(MIN_SPEED, vmax));
 
-		/* ---- speed limits ---- for modes calc */
-		switch (this.mode) {
-			case 'BASE':
-				vmax = vmax; // no change
-				break;
-			case 'PUSH':
-				vmax = sec.zone === Zone.ACCEL ? vmax * PUSH_VMAX_STRAIGHT : vmax * PUSH_VMAX_BRAKE;
-				break;
-			case 'CONSERVE':
-				vmax *= 0.9; // 10% slower
-				break;
-		}
-		/* ---- simple accel / brake rules ---- */
-		if (sec.zone === Zone.ACCEL) {
+		if (!inCorner) {
 			if (this.v < vmax) this.v = Math.min(vmax, this.v + accel * dt);
 			else if (this.v > vmax) this.v = Math.max(vmax, this.v - brake * dt);
 		} else {
-			// BRAKE zone
 			if (this.v > vmax) this.v = Math.max(vmax, this.v - brake * dt);
-			else if (this.v < vmax) this.v = Math.min(vmax, this.v + accel * dt * 0.25); // minor throttle to keep pace
+			else if (this.v < vmax) this.v = Math.min(vmax, this.v + accel * dt * 0.24);
 		}
 
-		/* ---- advance distance & cartesian coords ---- */
 		this.d += this.v * dt;
 		const secNew = track.sectorAt(this.d);
-		// console.log(Math.abs(secNew.curv));
 		this.x = secNew.p.x;
 		this.y = secNew.p.y;
 	}
 
 	snapshot() {
-		return { x: this.x, y: this.y, v: this.v, ers: this.ers, mode: this.mode };
+		return { x: this.x, y: this.y, v: this.v, ers: this.battery, mode: this.mode };
 	}
 }

--- a/ra-backend/src/room.ts
+++ b/ra-backend/src/room.ts
@@ -289,7 +289,7 @@ export class RoomDO implements DurableObject {
 			players: Object.fromEntries(
 				[...this.room.players.values()].map(p => [
 					p.id,
-					{ x: p.x, y: p.y, v: p.v, ers: p.ers, mode: p.mode }
+					{ x: p.x, y: p.y, v: p.v, ers: p.battery, mode: p.mode }
 				])
 			),
 			standings: this.room.standings,      // << NEW – already ordered

--- a/ra-backend/src/types.ts
+++ b/ra-backend/src/types.ts
@@ -1,5 +1,5 @@
 
-export type InputType = "BASE" | "PUSH" | "ERS" | "CONSERVE";
+export type InputType = "RACE" | "ATTACK" | "DEPLOY" | "HARVEST" | "XMODE" | "ZMODE";
 
 export type ClientMsg =
 	| { type: "join"; playerId: string; }

--- a/ra-frontend/app/game/[roomId]/page.tsx
+++ b/ra-frontend/app/game/[roomId]/page.tsx
@@ -9,7 +9,7 @@ import CommandPanel from '@/components/CommandPanel';
 import PlayersList from '@/components/PlayersList';
 import TelemetryBar from '@/components/TelemetryBar';
 import TrackCanvas from '@/components/TrackCanvas';
-import { useRaceSocket } from '@/hooks/useRaceSocket';
+import { useRaceSocket, type InputType } from '@/hooks/useRaceSocket';
 import ResultsOverlay from '@/components/ResultsOverlay';
 import { useRouter } from 'next/navigation';
 
@@ -97,12 +97,12 @@ export default function RacePage({ params }: Props) {
 		send({ type: 'ready', playerId: userId });
 	}
 
-	const handleRadio = (cmd: string) => {
+	const handleRadio = (cmd: InputType) => {
 		send({ type: 'input', playerId: userId, input: cmd });
 	};
 
 	return (
-		<div className="flex min-h-screen flex-col bg-gradient-to-b from-black via-neutral-950 to-black">
+		<div className="flex min-h-screen flex-col bg-[radial-gradient(circle_at_top,#1e293b_0%,#020617_45%,#000000_100%)]">
 			{countdownDisplay !== null && (
 				<div className="fixed top-20 left-1/2 -translate-x-1/2 transform text-6xl font-bold text-white z-50 bg-black/0 px-6 py-2 rounded-xl shadow-xl">
 					{countdownDisplay}
@@ -120,14 +120,14 @@ export default function RacePage({ params }: Props) {
 					</Button>
 				</div>
 				<div className="flex items-center gap-2">
-					Lap {curLap} / {maxLaps ?? '--'}
+					Lap {Math.min(curLap + 1, maxLaps || curLap + 1)} / {maxLaps ?? '--'}
 				</div>
 
 				<span className="text-sm text-muted-foreground">Room {roomId}</span>
 			</header>
 
 			{/* main grid */}
-			<div className="grid flex-1 grid-cols-[260px_1fr_360px] grid-rows-[1fr_auto] gap-4 p-4">
+			<div className="grid flex-1 grid-cols-1 gap-4 p-4 xl:grid-cols-[300px_1fr_380px] xl:grid-rows-[1fr_auto]">
 				<CommandPanel onSend={handleRadio} />
 
 				<Suspense fallback={<div className="rounded bg-neutral-900/40" />}>
@@ -135,7 +135,7 @@ export default function RacePage({ params }: Props) {
 				</Suspense>
 
 				{ready && me ? <PlayersList cars={cars} standings={standings} maxLaps={maxLaps} meId={userId ?? undefined} /> : null}
-				<div className="col-span-3">
+				<div className="xl:col-span-3">
 					<TelemetryBar car={me} />
 				</div>
 			</div>

--- a/ra-frontend/components/CommandPanel.tsx
+++ b/ra-frontend/components/CommandPanel.tsx
@@ -1,36 +1,57 @@
 'use client';
+
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import type { InputType } from '@/hooks/useRaceSocket';
+import clsx from 'clsx';
 
-const COMMANDS = ['BASE', 'CONSERVE', 'PUSH', 'ERS'];
+const COMMANDS: Array<{ key: InputType; label: string; desc: string; accent: string }> = [
+	{ key: 'RACE', label: 'Race', desc: 'Balanced baseline mapping', accent: 'from-slate-600 to-slate-500' },
+	{ key: 'ATTACK', label: 'Attack', desc: 'Extra pace with moderate battery drain', accent: 'from-orange-600 to-amber-500' },
+	{ key: 'DEPLOY', label: 'Deploy', desc: 'Maximum electrical deployment for overtakes', accent: 'from-fuchsia-600 to-pink-500' },
+	{ key: 'HARVEST', label: 'Harvest', desc: 'Lift-and-coast to refill battery', accent: 'from-emerald-700 to-green-500' },
+	{ key: 'XMODE', label: 'X Mode', desc: 'Low drag straight-line setup', accent: 'from-cyan-600 to-sky-500' },
+	{ key: 'ZMODE', label: 'Z Mode', desc: 'High downforce corner setup', accent: 'from-indigo-700 to-violet-600' },
+];
 
-export default function CommandPanel({ onSend }: { onSend: (cmd: string) => void }) {
+export default function CommandPanel({ onSend }: { onSend: (cmd: InputType) => void }) {
+	const [active, setActive] = useState<InputType>('RACE');
 	const [log, setLog] = useState<string[]>([]);
 
-	const send = (cmd: string) => {
+	const send = (cmd: InputType) => {
 		const stamp = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-		setLog((l) => [`${stamp} – ${cmd}`, ...l]);
+		setActive(cmd);
+		setLog((l) => [`${stamp} · ${cmd}`, ...l].slice(0, 10));
 		onSend(cmd);
 	};
 
 	return (
-		<Card className="flex h-full flex-col">
-			<CardHeader className="pb-2 text-lg font-semibold">Radio</CardHeader>
-			<CardContent className="flex flex-1 flex-col gap-3 py-2">
-				<div className="grid grid-cols-2 gap-2">
-					{COMMANDS.map((c) => (
-						<Button key={c} variant="secondary" size="sm" onClick={() => send(c)}>
-							{c}
+		<Card className="border-neutral-800 bg-neutral-900/70 text-white backdrop-blur">
+			<CardHeader className="pb-1 text-lg font-semibold">Race Engineer</CardHeader>
+			<CardContent className="space-y-3">
+				<div className="grid gap-2">
+					{COMMANDS.map((cmd) => (
+						<Button
+							key={cmd.key}
+							onClick={() => send(cmd.key)}
+							variant="secondary"
+							className={clsx(
+								'justify-start border border-white/10 bg-gradient-to-r text-left h-auto py-2 px-3',
+								cmd.accent,
+								active === cmd.key ? 'ring-2 ring-white/70' : 'opacity-85 hover:opacity-100'
+							)}
+						>
+							<div>
+								<p className="text-sm font-semibold uppercase tracking-wide">{cmd.label}</p>
+								<p className="text-xs text-white/85">{cmd.desc}</p>
+							</div>
 						</Button>
 					))}
 				</div>
-				<div className="mt-3  max-h-84 flex-1 overflow-y-auto rounded border p-2 text-sm">
-					{log.length === 0 ? (
-						<p className="text-muted-foreground">No messages yet.</p>
-					) : (
-						log.map((m, i) => <p key={i}>{m}</p>)
-					)}
+				<div className="rounded-md border border-neutral-700 bg-black/30 p-2 text-xs">
+					<p className="mb-1 font-medium text-white/80">Radio Log</p>
+					{log.length === 0 ? <p className="text-white/50">No instructions yet.</p> : log.map((line, idx) => <p key={idx}>{line}</p>)}
 				</div>
 			</CardContent>
 		</Card>

--- a/ra-frontend/components/PlayersList.tsx
+++ b/ra-frontend/components/PlayersList.tsx
@@ -24,8 +24,8 @@ export default function PlayersList({ cars, standings = [], meId, maxLaps }: Pro
 	const orderedIds = standings.length ? standings.map((s) => s.id) : Object.keys(cars).sort();
 
 	return (
-		<Card className="h-full overflow-y-auto border border-neutral-800 bg-neutral-900/50 backdrop-blur-md">
-			<CardHeader className="pb-2 text-lg font-semibold">Drivers</CardHeader>
+		<Card className="h-full overflow-y-auto border border-neutral-800 bg-neutral-900/70 text-white backdrop-blur-md">
+			<CardHeader className="pb-2 text-lg font-semibold">Live Classification</CardHeader>
 			<CardContent className="flex flex-col gap-3 py-2">
 				{orderedIds.length === 0 && <p className="text-sm text-muted-foreground">Waiting…</p>}
 
@@ -34,7 +34,7 @@ export default function PlayersList({ cars, standings = [], meId, maxLaps }: Pro
 					const standing = standings.find((s) => s.id === id);
 
 					// progress within the current lap (0‑100%)
-					const lapProgressPct = standing ? ((standing.progress % standing.totalDist) / standing.totalDist) * 100 : 0;
+					const lapProgressPct = standing && standing.totalDist > 0 ? (standing.progress / standing.totalDist) * 100 : 0;
 
 					return (
 						<div

--- a/ra-frontend/components/ResultsOverlay.tsx
+++ b/ra-frontend/components/ResultsOverlay.tsx
@@ -56,7 +56,7 @@ export default function ResultsOverlay({ open, standings, onClose }: Props) {
 				{/* --- header with trophy -------------------------------- */}
 				<DialogHeader className="items-center gap-2 pb-4">
 					<Trophy className="h-9 w-9 animate-bounce text-yellow-400" />
-					<DialogTitle className="text-center text-3xl font-extrabold">Race&nbsp;Finished!</DialogTitle>
+					<DialogTitle className="text-center text-3xl font-extrabold">Chequered Flag</DialogTitle>
 				</DialogHeader>
 
 				{/* --- winner callout ------------------------------------ */}
@@ -94,7 +94,7 @@ export default function ResultsOverlay({ open, standings, onClose }: Props) {
 
 				{/* --- close btn ---------------------------------------- */}
 				<Button variant="secondary" className="mt-5 w-full bg-red-600 hover:bg-red-500" onClick={onClose}>
-					Continue
+					Return to garage
 				</Button>
 			</DialogContent>
 		</Dialog>

--- a/ra-frontend/components/TelemetryBar.tsx
+++ b/ra-frontend/components/TelemetryBar.tsx
@@ -1,28 +1,45 @@
-"use client";
-import type { PlayerSnapshot } from "@/hooks/useRaceSocket";
+'use client';
+
+import type { PlayerSnapshot } from '@/hooks/useRaceSocket';
+import clsx from 'clsx';
+
+const modeTint: Record<string, string> = {
+	RACE: 'bg-slate-600/60',
+	ATTACK: 'bg-orange-500/70',
+	DEPLOY: 'bg-pink-500/70',
+	HARVEST: 'bg-emerald-600/70',
+	XMODE: 'bg-cyan-500/70',
+	ZMODE: 'bg-indigo-500/70',
+};
 
 export default function TelemetryBar({ car }: { car?: PlayerSnapshot | '' }) {
-  return (
-    <div className="flex items-center gap-6 bg-neutral-900 p-3 text-sm text-white/90">
-      <div>
-        Speed:{" "}
-        <span className="font-semibold">
-          {car ? `${Math.round(car.v * 3600/1000)} km/h` : "--"}
-        </span>
-      </div>
-      <div>
-        ERS:{" "}
-        <span className="font-semibold">
-          {car ? `${Math.round(car.ers)}%` : "--"}
-        </span>
-      </div>
-      <div>
-        Mode:{" "}
-        <span className="font-semibold">
-          {car ? car.mode : "--"}
-        </span>
-      </div>
-      
-    </div>
-  );
+	const speedKmh = car ? Math.round((car.v * 3600) / 1000) : 0;
+	const battery = car ? Math.max(0, Math.min(100, Math.round(car.ers))) : 0;
+	const mode = car ? car.mode : '--';
+
+	return (
+		<div className="grid grid-cols-1 gap-3 rounded-xl border border-neutral-700 bg-neutral-900/80 p-4 text-white md:grid-cols-3">
+			<div>
+				<p className="text-xs uppercase tracking-widest text-white/60">Speed</p>
+				<p className="text-2xl font-bold tabular-nums">{car ? `${speedKmh} km/h` : '--'}</p>
+			</div>
+
+			<div>
+				<div className="flex items-end justify-between">
+					<p className="text-xs uppercase tracking-widest text-white/60">Energy Store</p>
+					<p className="text-lg font-semibold tabular-nums">{car ? `${battery}%` : '--'}</p>
+				</div>
+				<div className="mt-1 h-2 overflow-hidden rounded-full bg-white/10">
+					<div className="h-full rounded-full bg-gradient-to-r from-emerald-400 via-cyan-400 to-blue-500" style={{ width: `${battery}%` }} />
+				</div>
+			</div>
+
+			<div>
+				<p className="text-xs uppercase tracking-widest text-white/60">Aero / Power Mode</p>
+				<div className={clsx('mt-1 inline-block rounded-md px-3 py-1 text-sm font-semibold', modeTint[mode] ?? 'bg-white/10')}>
+					{mode}
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/ra-frontend/components/TrackCanvas.tsx
+++ b/ra-frontend/components/TrackCanvas.tsx
@@ -24,10 +24,12 @@ interface Props {
    Per-mode look-up table
 ------------------------------------------------------------ */
 const MODE_STYLE: Record<InputType, { stroke: string; width: number }> = {
-	BASE: { stroke: '#0f172a', width: 2 }, // slate-900
-	PUSH: { stroke: '#f97316', width: 4 }, // orange-500
-	ERS: { stroke: '#38bdf8', width: 5 }, // sky-400
-	CONSERVE: { stroke: '#4ade80', width: 3 }, // green-400
+	RACE: { stroke: '#64748b', width: 2 },
+	ATTACK: { stroke: '#f97316', width: 4 },
+	DEPLOY: { stroke: '#ec4899', width: 5 },
+	HARVEST: { stroke: '#22c55e', width: 3 },
+	XMODE: { stroke: '#06b6d4', width: 5 },
+	ZMODE: { stroke: '#6366f1', width: 4 },
 };
 
 export default function TrackCanvas({ track, cars, positions }: Props) {
@@ -108,7 +110,7 @@ export default function TrackCanvas({ track, cars, positions }: Props) {
 			ctx.fill();
 
 			// outer ring – mode indicator
-			const mode = p.mode ?? 'BASE';
+			const mode = p.mode ?? 'RACE';
 			const { stroke, width } = MODE_STYLE[mode];
 			ctx.lineWidth = width;
 			ctx.strokeStyle = stroke;
@@ -118,5 +120,5 @@ export default function TrackCanvas({ track, cars, positions }: Props) {
 		});
 	}, [cars, positions, trackPts]);
 
-	return <canvas ref={ref} className="h-full w-full rounded bg-neutral-900/40" width={1500} height={625} />;
+	return <canvas ref={ref} className="h-full w-full rounded-xl border border-neutral-700 bg-gradient-to-b from-neutral-950 to-neutral-900" width={1500} height={625} />;
 }

--- a/ra-frontend/hooks/useRaceSocket.ts
+++ b/ra-frontend/hooks/useRaceSocket.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-export type InputType = "BASE" | "PUSH" | "ERS" | "CONSERVE";
+export type InputType = "RACE" | "ATTACK" | "DEPLOY" | "HARVEST" | "XMODE" | "ZMODE";
 
 export type ClientMsg =
 	| { type: "join"; playerId: string; }
@@ -60,8 +60,6 @@ function colorFromId(id: string) {
 	return `hsl(${hue} 80% 60%)`;
 }
 
-/* ---------- util ---------- */
-const randColor = () => `hsl(${Math.floor(Math.random() * 360)} 80% 60%)`;
 
 /* ------------------------------------------------------------------
    useRaceSocket – the simplest possible WebSocket hook


### PR DESCRIPTION
### Motivation

- Modernize the race simulation to match a 2026-style F1 ruleset with new aero/power strategies and a battery-backed deployment/harvesting model.
- Replace the legacy simple modes with a richer set of tactical choices so gameplay better reflects distinct straight/corner and brake-zone behaviour.
- Improve in-race UX and telemetry so players can see and command these new strategies more clearly.

### Description

- Replaced the backend physics with a 2026-inspired simulation in `ra-backend/src/physics.ts` implementing new modes `RACE | ATTACK | DEPLOY | HARVEST | XMODE | ZMODE`, zone-aware speed profiles, and a percent-based battery (`battery`) with drain/regen rules and corner-only regen.
- Updated message typing in `ra-backend/src/types.ts` and adapted the room broadcast in `ra-backend/src/room.ts` so the server emits the new `mode` and battery-backed `ers` value in state payloads (`{ x, y, v, ers, mode }`).
- Frontend contract and socket hook were updated in `ra-frontend/hooks/useRaceSocket.ts` to use the new `InputType` and player snapshot shape, and `TrackCanvas`, `PlayersList`, `TelemetryBar`, `CommandPanel`, and `ResultsOverlay` were refactored to present the new modes and battery UI (improved visuals, mode colors, energy bar, mode badges, and richer Race Engineer panel).
- Layout and page polish applied to `ra-frontend/app/game/[roomId]/page.tsx` for a refreshed background, responsive grid changes, typed radio commands, and improved lap display logic.

### Testing

- Ran `cd ra-frontend && pnpm lint`, which completed successfully but reported existing React Hooks dependency warnings that were not introduced by these changes.
- Ran `cd ra-backend && pnpm -s tsc --noEmit`, which completed with no TypeScript errors after adjusting backend snapshots to use the new `battery` field as `ers` in broadcasts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8aebc9338832383593af226d3c8f8)